### PR TITLE
Fix blank weight chart bug

### DIFF
--- a/lib/screens/WeightTrackingScreen.dart
+++ b/lib/screens/WeightTrackingScreen.dart
@@ -671,33 +671,39 @@ class _WeightTrackingScreenState extends State<WeightTrackingScreen>
       _weightData.sort((a, b) => DateTime.parse(a['date'] as String)
           .compareTo(DateTime.parse(b['date'] as String)));
 
-      // Get first and last entries based on selected time frame
-      final firstEntry = _filterWeightDataByTimeFrame(_weightData).first;
-      final lastEntry = _filterWeightDataByTimeFrame(_weightData).last;
+      // Get filtered data for the selected time frame
+      final filteredData = _filterWeightDataByTimeFrame(_weightData);
+      
+      // Only calculate statistics if we have filtered data
+      if (filteredData.isNotEmpty) {
+        // Get first and last entries based on selected time frame
+        final firstEntry = filteredData.first;
+        final lastEntry = filteredData.last;
 
-      // Calculate change
-      final startWeight = firstEntry['weight'] as double;
-      final endWeight = lastEntry['weight'] as double;
-      weightChange = endWeight - startWeight;
+        // Calculate change
+        final startWeight = firstEntry['weight'] as double;
+        final endWeight = lastEntry['weight'] as double;
+        weightChange = endWeight - startWeight;
 
-      // Format time description
-      final startDate = DateTime.parse(firstEntry['date'] as String);
-      final endDate = DateTime.parse(lastEntry['date'] as String);
-      final days = endDate.difference(startDate).inDays;
+        // Format time description
+        final startDate = DateTime.parse(firstEntry['date'] as String);
+        final endDate = DateTime.parse(lastEntry['date'] as String);
+        final days = endDate.difference(startDate).inDays;
 
-      if (days < 7) {
-        timeDescription = days == 0
-            ? 'today'
-            : 'in the last $days day${days == 1 ? '' : 's'}';
-      } else if (days < 30) {
-        final weeks = (days / 7).floor();
-        timeDescription = 'in the last $weeks week${weeks == 1 ? '' : 's'}';
-      } else if (days < 365) {
-        final months = (days / 30).floor();
-        timeDescription = 'in the last $months month${months == 1 ? '' : 's'}';
-      } else {
-        final years = (days / 365).floor();
-        timeDescription = 'in the last $years year${years == 1 ? '' : 's'}';
+        if (days < 7) {
+          timeDescription = days == 0
+              ? 'today'
+              : 'in the last $days day${days == 1 ? '' : 's'}';
+        } else if (days < 30) {
+          final weeks = (days / 7).floor();
+          timeDescription = 'in the last $weeks week${weeks == 1 ? '' : 's'}';
+        } else if (days < 365) {
+          final months = (days / 30).floor();
+          timeDescription = 'in the last $months month${months == 1 ? '' : 's'}';
+        } else {
+          final years = (days / 365).floor();
+          timeDescription = 'in the last $years year${years == 1 ? '' : 's'}';
+        }
       }
     }
 
@@ -774,36 +780,55 @@ class _WeightTrackingScreenState extends State<WeightTrackingScreen>
                     if (_weightData.length > 1)
                       Padding(
                         padding: const EdgeInsets.only(top: 8, bottom: 16),
-                        child: Row(
-                          children: [
-                            Icon(
-                              weightChange > 0
-                                  ? Icons.arrow_upward
-                                  : weightChange < 0
-                                      ? Icons.arrow_downward
-                                      : Icons.remove,
-                              size: 16,
-                              color: weightChange > 0
-                                  ? Colors.redAccent
-                                  : weightChange < 0
-                                      ? Colors.greenAccent.shade700
-                                      : customColors.textSecondary,
-                            ),
-                            const SizedBox(width: 4),
-                            Text(
-                              '${convertedChange.abs().toStringAsFixed(1)} ${unitProvider.unitLabel} ${weightChange > 0 ? 'gained' : weightChange < 0 ? 'lost' : 'maintained'} $timeDescription',
-                              style: GoogleFonts.inter(
-                                fontSize: 13,
-                                fontWeight: FontWeight.w500,
-                                color: weightChange > 0
-                                    ? Colors.redAccent
-                                    : weightChange < 0
-                                        ? Colors.greenAccent.shade700
-                                        : customColors.textSecondary,
+                        child: _filterWeightDataByTimeFrame(_weightData).isNotEmpty
+                            ? Row(
+                                children: [
+                                  Icon(
+                                    weightChange > 0
+                                        ? Icons.arrow_upward
+                                        : weightChange < 0
+                                            ? Icons.arrow_downward
+                                            : Icons.remove,
+                                    size: 16,
+                                    color: weightChange > 0
+                                        ? Colors.redAccent
+                                        : weightChange < 0
+                                            ? Colors.greenAccent.shade700
+                                            : customColors.textSecondary,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    '${convertedChange.abs().toStringAsFixed(1)} ${unitProvider.unitLabel} ${weightChange > 0 ? 'gained' : weightChange < 0 ? 'lost' : 'maintained'} $timeDescription',
+                                    style: GoogleFonts.inter(
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w500,
+                                      color: weightChange > 0
+                                          ? Colors.redAccent
+                                          : weightChange < 0
+                                              ? Colors.greenAccent.shade700
+                                              : customColors.textSecondary,
+                                    ),
+                                  ),
+                                ],
+                              )
+                            : Row(
+                                children: [
+                                  Icon(
+                                    Icons.info_outline,
+                                    size: 16,
+                                    color: customColors.textSecondary,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    'No data for this ${_selectedTimeFrame.toLowerCase()}',
+                                    style: GoogleFonts.inter(
+                                      fontSize: 13,
+                                      fontWeight: FontWeight.w500,
+                                      color: customColors.textSecondary,
+                                    ),
+                                  ),
+                                ],
                               ),
-                            ),
-                          ],
-                        ),
                       ),
 
                     // Chart
@@ -2039,7 +2064,7 @@ class _WeightChartPainter extends CustomPainter {
       fontWeight: FontWeight.w500,
     );
 
-    const text = 'No weight data available';
+    final text = 'No weight data for this ${timeFrame.toLowerCase()}';
     final textSpan = TextSpan(text: text, style: textStyle);
     final textPainter = TextPainter(
       text: textSpan,


### PR DESCRIPTION
Prevent weight chart from crashing and display appropriate message when no data exists for the selected timeframe.

The previous implementation would attempt to access `.first` and `.last` on an empty list of filtered weight data, leading to a `StateError` and a blank screen if, for example, monthly data was present but no data existed for the current week. This PR introduces checks to safely handle empty data, providing a clear "No data for this [timeframe]" message to the user.

---
Linear Issue: [SHA-120](https://linear.app/sharath-chenna/issue/SHA-120/issue-with-weight-chart)

<a href="https://cursor.com/background-agent?bcId=bc-f50a7224-f9f0-4241-b083-41dcca88ee9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f50a7224-f9f0-4241-b083-41dcca88ee9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

