### PR TITLE
Updated Superwall and added redeem button

### DIFF
--- a/docs/ios_app_store_redemption_methods.md
+++ b/docs/ios_app_store_redemption_methods.md
@@ -1,0 +1,293 @@
+# iOS App Store Redemption Methods in Flutter
+
+This document explains the different ways to call the App Store native redemption page in Flutter for iOS applications.
+
+## Overview
+
+There are two main approaches to present the App Store redemption functionality in Flutter iOS apps:
+
+1. **Native Redemption Sheet (Recommended)** - Using `in_app_purchase` package
+2. **URL Scheme Redirect** - Using `url_launcher` package (current implementation)
+
+## Method 1: Native Redemption Sheet (Recommended)
+
+The native redemption sheet provides the best user experience by presenting Apple's built-in code redemption interface directly within your app without leaving the application.
+
+### Dependencies Required
+
+Add to your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  in_app_purchase: ^3.2.2
+```
+
+### Implementation
+
+```dart
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:in_app_purchase_storekit/in_app_purchase_storekit.dart';
+
+class RedemptionService {
+  /// Present the native iOS App Store code redemption sheet
+  static Future<void> presentNativeRedemptionSheet() async {
+    try {
+      // Get the iOS platform addition
+      InAppPurchaseStoreKitPlatformAddition iosPlatformAddition =
+          InAppPurchase.instance.getPlatformAddition<InAppPurchaseStoreKitPlatformAddition>();
+      
+      // Present the native redemption sheet
+      await iosPlatformAddition.presentCodeRedemptionSheet();
+      
+      debugPrint('[RedemptionService] Native redemption sheet presented successfully');
+    } catch (e) {
+      debugPrint('[RedemptionService] Error presenting native redemption sheet: $e');
+    }
+  }
+}
+```
+
+### Usage
+
+```dart
+// Call from any widget or service
+await RedemptionService.presentNativeRedemptionSheet();
+```
+
+### Advantages
+- ✅ Native iOS interface
+- ✅ User stays within the app
+- ✅ Better user experience
+- ✅ Handles success/failure states automatically
+- ✅ Works with iOS 14+ offer codes
+
+### Limitations
+- ❌ iOS only (requires platform-specific handling for Android)
+- ❌ Requires `in_app_purchase` dependency
+
+## Method 2: URL Scheme Redirect (Current Implementation)
+
+This method redirects users to the App Store app using URL schemes.
+
+### Dependencies Required
+
+```yaml
+dependencies:
+  url_launcher: ^6.2.2
+```
+
+### Implementation
+
+```dart
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class RedemptionService {
+  /// Open iOS App Store redeem page using URL scheme
+  static Future<void> openIOSRedeemPage() async {
+    try {
+      // iOS App Store redeem URL
+      const String redeemUrl = 'itms-apps://apps.apple.com/account/balance/redeem';
+      
+      final Uri uri = Uri.parse(redeemUrl);
+      
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+        debugPrint('[RedemptionService] Successfully opened iOS App Store redeem page');
+      } else {
+        debugPrint('[RedemptionService] Could not launch iOS App Store redeem page');
+        throw Exception('Could not launch App Store redeem page');
+      }
+    } catch (e) {
+      debugPrint('[RedemptionService] Error opening iOS App Store redeem page: $e');
+      rethrow;
+    }
+  }
+}
+```
+
+### Alternative URL Schemes
+
+```dart
+// Different URL schemes you can use:
+const String redeemUrlScheme1 = 'itms-apps://apps.apple.com/account/balance/redeem';
+const String redeemUrlScheme2 = 'https://apps.apple.com/redeem';
+const String redeemUrlScheme3 = 'itms://apps.apple.com/redeem';
+```
+
+### Advantages
+- ✅ Works on all iOS versions
+- ✅ Simple implementation
+- ✅ Cross-platform compatible (can handle Android separately)
+- ✅ Lightweight dependency
+
+### Limitations
+- ❌ User leaves the app
+- ❌ Less integrated user experience
+- ❌ URL schemes might change over time
+
+## Platform-Specific Implementation
+
+### Complete Cross-Platform Solution
+
+```dart
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:in_app_purchase_storekit/in_app_purchase_storekit.dart';
+
+class UniversalRedemptionService {
+  /// Present redemption interface based on platform and preference
+  static Future<void> presentRedemption({bool useNativeSheet = true}) async {
+    if (Platform.isIOS) {
+      if (useNativeSheet) {
+        await _presentNativeIOSRedemptionSheet();
+      } else {
+        await _openIOSRedeemPageWithURL();
+      }
+    } else if (Platform.isAndroid) {
+      await _openAndroidRedeemPage();
+    } else {
+      throw UnsupportedError('Redemption not supported on this platform');
+    }
+  }
+
+  /// Present native iOS redemption sheet
+  static Future<void> _presentNativeIOSRedemptionSheet() async {
+    try {
+      InAppPurchaseStoreKitPlatformAddition iosPlatformAddition =
+          InAppPurchase.instance.getPlatformAddition<InAppPurchaseStoreKitPlatformAddition>();
+      
+      await iosPlatformAddition.presentCodeRedemptionSheet();
+      debugPrint('[RedemptionService] Native iOS redemption sheet presented');
+    } catch (e) {
+      debugPrint('[RedemptionService] Native sheet failed, falling back to URL: $e');
+      await _openIOSRedeemPageWithURL();
+    }
+  }
+
+  /// Open iOS App Store using URL scheme
+  static Future<void> _openIOSRedeemPageWithURL() async {
+    const String redeemUrl = 'itms-apps://apps.apple.com/account/balance/redeem';
+    final Uri uri = Uri.parse(redeemUrl);
+    
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } else {
+      throw Exception('Could not launch iOS App Store redeem page');
+    }
+  }
+
+  /// Open Android Play Store redeem page
+  static Future<void> _openAndroidRedeemPage() async {
+    const String redeemUrl = 'https://play.google.com/store/gift';
+    final Uri uri = Uri.parse(redeemUrl);
+    
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    } else {
+      throw Exception('Could not launch Play Store redeem page');
+    }
+  }
+}
+```
+
+## Integration with Your Current Implementation
+
+### Updating SuperwallDelegate
+
+```dart
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:in_app_purchase_storekit/in_app_purchase_storekit.dart';
+
+class CustomSuperwallDelegate {
+  /// Handle the 'redeem' custom action with native sheet option
+  void handleRedeemAction({bool useNativeSheet = true}) {
+    debugPrint('[SuperwallDelegate] Opening App Store redeem page...');
+    
+    if (Platform.isIOS) {
+      if (useNativeSheet) {
+        _presentNativeIOSRedemptionSheet();
+      } else {
+        _openIOSRedeemPage(); // Your existing implementation
+      }
+    } else if (Platform.isAndroid) {
+      _openAndroidRedeemPage();
+    } else {
+      debugPrint('[SuperwallDelegate] Redeem action not supported on this platform');
+    }
+  }
+
+  /// Present native iOS redemption sheet
+  Future<void> _presentNativeIOSRedemptionSheet() async {
+    try {
+      InAppPurchaseStoreKitPlatformAddition iosPlatformAddition =
+          InAppPurchase.instance.getPlatformAddition<InAppPurchaseStoreKitPlatformAddition>();
+      
+      await iosPlatformAddition.presentCodeRedemptionSheet();
+      debugPrint('[SuperwallDelegate] Native redemption sheet presented successfully');
+    } catch (e) {
+      debugPrint('[SuperwallDelegate] Native sheet failed, falling back to URL: $e');
+      _openIOSRedeemPage(); // Fallback to your existing URL method
+    }
+  }
+
+  // Your existing _openIOSRedeemPage() method remains the same as fallback
+}
+```
+
+## Recommendations
+
+### For MacroTracker App
+
+Based on your current implementation, I recommend:
+
+1. **Add `in_app_purchase` dependency** to enable native redemption sheet
+2. **Keep your current URL-based method as fallback**
+3. **Use native sheet as primary method** for better UX
+4. **Update your SuperwallDelegate** to support both methods
+
+### Migration Steps
+
+1. Add `in_app_purchase: ^3.2.2` to `pubspec.yaml`
+2. Update your `CustomSuperwallDelegate` class
+3. Test both methods thoroughly
+4. Consider adding user preference for redemption method
+
+## Testing
+
+### Test Cases
+
+```dart
+// Test native redemption sheet
+await UniversalRedemptionService.presentRedemption(useNativeSheet: true);
+
+// Test URL fallback
+await UniversalRedemptionService.presentRedemption(useNativeSheet: false);
+
+// Test platform detection
+if (Platform.isIOS) {
+  // Test iOS-specific functionality
+}
+```
+
+### Error Handling
+
+```dart
+try {
+  await UniversalRedemptionService.presentRedemption();
+} catch (e) {
+  // Handle redemption errors
+  showErrorDialog('Could not open redemption page: $e');
+}
+```
+
+## Conclusion
+
+The **native redemption sheet** using `in_app_purchase` package is the recommended approach for iOS as it provides the best user experience. Your current URL-based implementation works well as a fallback method and for maintaining cross-platform compatibility.
+
+Both methods are valid, and you can choose based on your specific needs:
+- Use **native sheet** for premium user experience
+- Use **URL scheme** for simplicity and cross-platform consistency

--- a/docs/superwall_custom_redeem_action.md
+++ b/docs/superwall_custom_redeem_action.md
@@ -1,0 +1,146 @@
+# Superwall Custom Actions Implementation - Redeem & Restore
+
+This document describes the implementation of custom actions in the Superwall SDK: a "redeem" action that opens the App Store redeem page, and a "restore" action that restores previous purchases via RevenueCat.
+
+## Overview
+
+The implementation provides a way to handle custom actions from Superwall paywalls:
+- **"redeem" action**: Opens the appropriate store's redeem page (App Store for iOS, Play Store for Android)
+- **"restore" action**: Restores previous purchases via RevenueCat
+
+## Implementation Details
+
+### Files Created/Modified
+
+1. **`lib/services/superwall_delegate.dart`** - Custom delegate class to handle redeem actions
+2. **`lib/services/superwall_service.dart`** - Updated to integrate the custom action handler
+
+### Key Components
+
+#### CustomSuperwallDelegate Class
+
+The `CustomSuperwallDelegate` class handles both custom actions:
+
+**Redeem Action:**
+- Detecting the platform (iOS/Android)
+- Opening the appropriate store redeem page
+- Handling errors gracefully
+
+**Restore Action:**
+- Restoring previous purchases via RevenueCat
+- Handling success/failure cases
+- Logging appropriate debug messages
+
+```dart
+class CustomSuperwallDelegate {
+  void handleRedeemAction() {
+    if (Platform.isIOS) {
+      _openIOSRedeemPage();
+    } else if (Platform.isAndroid) {
+      _openAndroidRedeemPage();
+    }
+  }
+  
+  void handleRestoreAction() {
+    _restorePurchases();
+  }
+}
+```
+
+#### Platform-Specific URLs
+
+- **iOS**: `itms-apps://apps.apple.com/account/balance/redeem`
+- **Android**: `https://play.google.com/store/gift`
+
+#### SuperwallService Integration
+
+The `SuperwallService` now includes both custom action handlers:
+
+```dart
+void handleRedeemAction() {
+  if (!_isConfigured) return;
+  _delegate.handleRedeemAction();
+}
+
+void handleRestoreAction() {
+  if (!_isConfigured) return;
+  _delegate.handleRestoreAction();
+}
+```
+
+## Usage
+
+### In Superwall Dashboard
+
+1. Create a paywall in the Superwall dashboard
+2. Add buttons or interactive elements
+3. Set the tap action to "Custom Action"
+4. Name the actions "redeem" or "restore"
+
+### In Your App Code
+
+When you need to trigger the custom actions programmatically:
+
+```dart
+// Get the SuperwallService instance
+final superwallService = SuperwallService();
+
+// Handle the redeem action
+superwallService.handleRedeemAction();
+
+// Handle the restore action
+superwallService.handleRestoreAction();
+```
+
+### From Paywall Interactions
+
+The custom actions will be automatically triggered when users interact with the "redeem" or "restore" buttons in your Superwall paywall, provided you've configured them correctly in the dashboard.
+
+## Error Handling
+
+The implementation includes error handling for:
+
+**Redeem Action:**
+- Unsupported platforms
+- URL launch failures
+- Network connectivity issues
+
+**Restore Action:**
+- RevenueCat API errors
+- Network connectivity issues
+- No previous purchases found
+
+Errors are logged using `debugPrint()` for debugging purposes.
+
+## Dependencies
+
+- `url_launcher: ^6.3.1` - Already included in pubspec.yaml
+- `superwallkit_flutter: ^2.4.2` - Already included in pubspec.yaml
+- `purchases_flutter: ^6.0.0` - Already included in pubspec.yaml
+
+## Testing
+
+To test the implementation:
+
+1. Ensure Superwall is properly configured
+2. Call `SuperwallService().handleRedeemAction()` to test redeem functionality
+3. Call `SuperwallService().handleRestoreAction()` to test restore functionality
+4. Verify that the appropriate store redeem page opens for redeem action
+5. Verify that purchases are restored for restore action
+6. Test on both iOS and Android devices
+
+## Notes
+
+- The Flutter Superwall package doesn't support the same delegate pattern as the iOS version
+- This implementation provides a workaround by creating a custom handler class
+- The implementation is platform-aware and opens the correct store for each platform
+- Error handling is basic and can be enhanced based on your app's requirements
+
+## Future Enhancements
+
+Consider adding:
+
+- User feedback dialogs for failed launches
+- Analytics tracking for redeem action usage
+- Fallback options if the store page fails to open
+- Custom error messages for different failure scenarios

--- a/docs/superwall_delegate_fix.md
+++ b/docs/superwall_delegate_fix.md
@@ -1,0 +1,189 @@
+# Superwall Custom Action Fix - Working Implementation
+
+This document explains the fix for the non-working redeem button in Superwall paywalls by implementing the proper `SuperwallDelegate` pattern.
+
+## Problem
+
+The redeem button wasn't working because we weren't properly implementing the Superwall Flutter SDK's delegate pattern. The custom actions from paywall buttons need to be handled through the official `SuperwallDelegate.handleCustomPaywallAction()` method.
+
+## Solution
+
+### 1. Extended Official SuperwallDelegate
+
+Updated `CustomSuperwallDelegate` to properly extend the official `SuperwallDelegate` class:
+
+```dart
+import 'package:superwallkit_flutter/superwallkit_flutter.dart';
+
+class CustomSuperwallDelegate extends SuperwallDelegate {
+  @override
+  void handleCustomPaywallAction(String name) {
+    debugPrint('[SuperwallDelegate] Received custom paywall action: $name');
+    
+    switch (name.toLowerCase()) {
+      case 'redeem':
+        handleRedeemAction();
+        break;
+      case 'restore':
+        handleRestoreAction();
+        break;
+      default:
+        debugPrint('[SuperwallDelegate] Unknown custom paywall action: $name');
+    }
+  }
+  
+  // ... rest of implementation
+}
+```
+
+### 2. Set Delegate in SuperwallService
+
+Updated the configuration to properly set the delegate:
+
+```dart
+// Configure Superwall with API key
+Superwall.configure(_apiKey);
+
+// Set the custom delegate to handle custom paywall actions
+Superwall.shared.setDelegate(_delegate);
+```
+
+### 3. Automatic Action Handling
+
+Now when users tap buttons with custom actions in your Superwall paywalls:
+
+1. **User taps "Redeem Code" button in paywall**
+2. **Superwall calls `handleCustomPaywallAction('redeem')`**
+3. **Our delegate automatically routes to the appropriate handler**
+4. **Native iOS redemption sheet is presented**
+
+## How It Works
+
+### Flow Diagram
+
+```
+Paywall Button (action: "redeem") 
+    ↓
+Superwall SDK detects custom action
+    ↓
+Calls SuperwallDelegate.handleCustomPaywallAction("redeem")
+    ↓
+CustomSuperwallDelegate routes to handleRedeemAction()
+    ↓
+Native iOS redemption sheet presented
+```
+
+### Configuration in Superwall Dashboard
+
+1. **Create/Edit your paywall**
+2. **Add a button element**
+3. **Set button action to "Custom Action"**
+4. **Set action name to "redeem"** (case insensitive)
+5. **Save and publish**
+
+### Testing
+
+You can test the implementation with:
+
+```dart
+// Test the delegate directly
+SuperwallService().testRedeemAction();
+
+// Or trigger through normal paywall flow
+SuperwallService().register(placement: 'your_placement');
+```
+
+## Key Changes Made
+
+### 1. Import SuperwallKit
+```dart
+import 'package:superwallkit_flutter/superwallkit_flutter.dart';
+```
+
+### 2. Extend Official Delegate
+```dart
+class CustomSuperwallDelegate extends SuperwallDelegate {
+```
+
+### 3. Override Required Method
+```dart
+@override
+void handleCustomPaywallAction(String name) {
+  // Handle custom actions here
+}
+```
+
+### 4. Set Delegate During Configuration
+```dart
+Superwall.shared.setDelegate(_delegate);
+```
+
+## Benefits
+
+✅ **Official SDK Pattern** - Uses the proper Superwall delegate pattern  
+✅ **Automatic Handling** - No manual intervention needed  
+✅ **Case Insensitive** - Action names work regardless of case  
+✅ **Extensible** - Easy to add more custom actions  
+✅ **Native Experience** - Full native iOS redemption sheet support  
+
+## Supported Custom Actions
+
+| Action Name | Description | Platform Support |
+|-------------|-------------|-------------------|
+| `redeem` | Opens native redemption sheet | iOS (native), Android (URL) |
+| `restore` | Restores previous purchases | iOS & Android |
+
+## Debug Logging
+
+The implementation includes comprehensive logging:
+
+```
+[SuperwallDelegate] Received custom paywall action: redeem
+[SuperwallDelegate] Opening App Store redeem page...
+[SuperwallDelegate] Presenting native iOS redemption sheet...
+[SuperwallDelegate] Native iOS redemption sheet presented successfully
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Button not responding**
+   - Verify action name is exactly "redeem" in dashboard
+   - Check delegate is properly set during configuration
+   - Look for error logs in console
+
+2. **Native sheet not appearing**
+   - Ensure testing on physical iOS device (not simulator)
+   - Verify `in_app_purchase` package is properly installed
+   - Check iOS version (requires iOS 14+)
+
+3. **Delegate not called**
+   - Verify `Superwall.shared.setDelegate(_delegate)` is called
+   - Ensure Superwall is properly configured before setting delegate
+   - Check that paywall is loaded from Superwall dashboard
+
+### Debug Commands
+
+```dart
+// Test if delegate is working
+SuperwallService().testRedeemAction();
+
+// Check configuration
+print('Superwall configured: ${SuperwallService().isConfigured}');
+
+// Manual action trigger (for testing)
+SuperwallService().handleCustomAction('redeem');
+```
+
+## Conclusion
+
+The redeem button should now work properly! The key was implementing the official `SuperwallDelegate.handleCustomPaywallAction()` method and setting the delegate during Superwall configuration.
+
+Users can now:
+1. Tap the "Redeem Code" button in your paywall
+2. See the native iOS App Store redemption sheet appear
+3. Enter their redemption code without leaving your app
+4. Have automatic fallback to URL method if needed
+
+This provides the best possible user experience for code redemption while maintaining reliability across all scenarios.

--- a/docs/superwall_native_redemption_implementation.md
+++ b/docs/superwall_native_redemption_implementation.md
@@ -1,0 +1,293 @@
+# Superwall Native Redemption Implementation
+
+This document describes how to create a custom action named "redeem" in Superwall that invokes the iOS native redemption sheet in your Flutter app.
+
+## Overview
+
+The implementation provides:
+- **Native iOS redemption sheet** using `in_app_purchase` package for the best user experience
+- **URL fallback method** for reliability and Android support
+- **Custom action handler** that integrates with Superwall paywalls
+- **Automatic platform detection** and appropriate method selection
+
+## Architecture
+
+```
+Superwall Dashboard → Custom Action "redeem" → SuperwallService → CustomSuperwallDelegate → Native Redemption Sheet
+```
+
+## Implementation Details
+
+### 1. Dependencies Added
+
+```yaml
+# pubspec.yaml
+dependencies:
+  in_app_purchase: ^3.2.2  # For native iOS redemption sheet
+  url_launcher: ^6.3.1     # For URL fallback (already present)
+  superwallkit_flutter: ^2.4.2  # Superwall SDK (already present)
+```
+
+### 2. Enhanced CustomSuperwallDelegate
+
+The delegate now supports both native redemption sheet and URL fallback:
+
+```dart
+class CustomSuperwallDelegate {
+  /// Handle the 'redeem' custom action with native sheet option
+  void handleRedeemAction({bool useNativeSheet = true}) {
+    if (Platform.isIOS) {
+      if (useNativeSheet) {
+        _presentNativeIOSRedemptionSheet();  // Primary method
+      } else {
+        _openIOSRedeemPage();  // Fallback method
+      }
+    } else if (Platform.isAndroid) {
+      _openAndroidRedeemPage();
+    }
+  }
+
+  /// Present native iOS App Store redemption sheet
+  Future<void> _presentNativeIOSRedemptionSheet() async {
+    try {
+      InAppPurchaseStoreKitPlatformAddition iosPlatformAddition =
+          InAppPurchase.instance.getPlatformAddition<InAppPurchaseStoreKitPlatformAddition>();
+      
+      await iosPlatformAddition.presentCodeRedemptionSheet();
+      debugPrint('[SuperwallDelegate] Native iOS redemption sheet presented successfully');
+    } catch (e) {
+      debugPrint('[SuperwallDelegate] Native redemption sheet failed: $e');
+      _openIOSRedeemPage(); // Automatic fallback to URL method
+    }
+  }
+}
+```
+
+### 3. SuperwallService Integration
+
+The service now includes a generic custom action handler:
+
+```dart
+class SuperwallService {
+  /// Handle custom action from Superwall paywall
+  void handleCustomAction(String actionName, {Map<String, dynamic>? parameters}) {
+    switch (actionName.toLowerCase()) {
+      case 'redeem':
+        final useNativeSheet = parameters?['useNativeSheet'] as bool? ?? true;
+        handleRedeemAction(useNativeSheet: useNativeSheet);
+        break;
+      case 'restore':
+        handleRestoreAction();
+        break;
+      default:
+        debugPrint('[SuperwallService] Unknown custom action: $actionName');
+    }
+  }
+}
+```
+
+## Setup Instructions
+
+### Step 1: Configure Superwall Dashboard
+
+1. **Login to your Superwall Dashboard**
+2. **Navigate to your Paywall**
+3. **Add a Button or Interactive Element**
+4. **Configure the Button Action:**
+   - Set Action Type to "Custom Action"
+   - Set Action Name to "redeem"
+   - Optionally add parameters like `{"useNativeSheet": true}`
+
+### Step 2: Paywall HTML Configuration
+
+If you're using custom HTML in your paywall, add this JavaScript:
+
+```javascript
+// In your paywall HTML
+function handleRedeemClick() {
+  // This will trigger the custom action in your Flutter app
+  window.webkit.messageHandlers.superwall.postMessage({
+    action: 'custom_action',
+    name: 'redeem',
+    parameters: {
+      useNativeSheet: true
+    }
+  });
+}
+```
+
+```html
+<!-- Button in your paywall HTML -->
+<button onclick="handleRedeemClick()">
+  Redeem Code
+</button>
+```
+
+### Step 3: Flutter App Integration
+
+The integration is already complete with your current implementation. The custom action will be automatically handled when triggered from the paywall.
+
+## Usage Examples
+
+### Programmatic Usage
+
+```dart
+// Direct method calls
+final superwallService = SuperwallService();
+
+// Use native sheet (default)
+superwallService.handleRedeemAction();
+
+// Use URL method
+superwallService.handleRedeemAction(useNativeSheet: false);
+
+// Handle generic custom action
+superwallService.handleCustomAction('redeem', parameters: {
+  'useNativeSheet': true
+});
+```
+
+### From Paywall Interactions
+
+When users interact with the "redeem" button in your Superwall paywall:
+
+1. **User taps "Redeem Code" button**
+2. **Superwall triggers custom action "redeem"**
+3. **SuperwallService.handleCustomAction() is called**
+4. **Native iOS redemption sheet is presented**
+5. **If native sheet fails, automatically falls back to URL method**
+
+## Platform-Specific Behavior
+
+### iOS
+- **Primary**: Native redemption sheet using `in_app_purchase`
+- **Fallback**: URL scheme `itms-apps://apps.apple.com/account/balance/redeem`
+- **User Experience**: Users stay within the app (native sheet) or are redirected to App Store app (URL)
+
+### Android
+- **Method**: URL redirect to Play Store
+- **URL**: `https://play.google.com/store/gift`
+- **User Experience**: Users are redirected to Play Store app
+
+### Other Platforms
+- **Behavior**: Logs unsupported platform message
+- **Fallback**: No action taken
+
+## Error Handling
+
+The implementation includes comprehensive error handling:
+
+```dart
+try {
+  // Attempt native redemption sheet
+  await iosPlatformAddition.presentCodeRedemptionSheet();
+} catch (e) {
+  // Automatic fallback to URL method
+  _openIOSRedeemPage();
+}
+```
+
+**Error Scenarios Handled:**
+- Native sheet API unavailable
+- Network connectivity issues
+- Platform-specific failures
+- URL launch failures
+
+## Testing
+
+### Test Cases
+
+1. **Native Sheet Test (iOS)**
+```dart
+SuperwallService().handleRedeemAction(useNativeSheet: true);
+```
+
+2. **URL Fallback Test (iOS)**
+```dart
+SuperwallService().handleRedeemAction(useNativeSheet: false);
+```
+
+3. **Android Test**
+```dart
+SuperwallService().handleRedeemAction();
+```
+
+4. **Custom Action Test**
+```dart
+SuperwallService().handleCustomAction('redeem');
+```
+
+### Testing Checklist
+
+- [ ] Native redemption sheet opens on iOS
+- [ ] URL fallback works when native sheet fails
+- [ ] Android redirects to Play Store correctly
+- [ ] Custom action from paywall triggers correctly
+- [ ] Error handling works properly
+- [ ] Debug logs are informative
+
+## Debugging
+
+### Enable Debug Logging
+
+All methods include comprehensive debug logging:
+
+```dart
+debugPrint('[SuperwallDelegate] Presenting native iOS redemption sheet...');
+debugPrint('[SuperwallService] Handling custom action: redeem');
+```
+
+### Common Issues
+
+1. **Native Sheet Not Appearing**
+   - Check iOS version (requires iOS 14+)
+   - Verify `in_app_purchase` package is properly installed
+   - Check device logs for StoreKit errors
+
+2. **URL Fallback Not Working**
+   - Verify `url_launcher` package permissions
+   - Check if device has App Store app installed
+   - Test URL scheme manually
+
+3. **Custom Action Not Triggered**
+   - Verify Superwall dashboard configuration
+   - Check paywall HTML/JavaScript
+   - Ensure SuperwallService is properly initialized
+
+## Advantages
+
+### Native Redemption Sheet
+✅ **Better User Experience** - Users stay within your app  
+✅ **Native iOS Interface** - Consistent with system design  
+✅ **Automatic Validation** - Built-in code validation  
+✅ **Success/Failure Handling** - Automatic result handling  
+
+### URL Fallback
+✅ **Universal Compatibility** - Works on all iOS versions  
+✅ **Reliable** - Doesn't depend on API availability  
+✅ **Cross-Platform** - Same approach works for Android  
+
+### Combined Approach
+✅ **Best of Both Worlds** - Premium UX with reliable fallback  
+✅ **Automatic Fallback** - Seamless error recovery  
+✅ **Platform Aware** - Optimized for each platform  
+
+## Future Enhancements
+
+Consider adding:
+- **Success/failure callbacks** for better UX feedback
+- **Analytics tracking** for redemption attempts
+- **Custom UI indicators** during redemption process
+- **A/B testing** between native sheet and URL methods
+- **User preference storage** for redemption method choice
+
+## Conclusion
+
+This implementation provides a robust, user-friendly way to handle code redemption in your Flutter app through Superwall custom actions. The native iOS redemption sheet offers the best user experience, while the URL fallback ensures reliability across all scenarios.
+
+The setup is straightforward:
+1. Configure "redeem" custom action in Superwall dashboard
+2. The Flutter implementation is already complete
+3. Test thoroughly on both iOS and Android devices
+
+Users will now have a seamless code redemption experience directly from your paywalls!

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -126,6 +126,9 @@ PODS:
     - Flutter
   - image_picker_ios (0.0.1):
     - Flutter
+  - in_app_purchase_storekit (0.0.1):
+    - Flutter
+    - FlutterMacOS
   - JPSVolumeButtonHandler (1.0.5)
   - libwebp (1.5.0):
     - libwebp/demux (= 1.5.0)
@@ -211,11 +214,11 @@ PODS:
     - Flutter
     - FlutterMacOS
   - Superscript (0.2.8)
-  - SuperwallKit (4.5.2):
+  - SuperwallKit (4.7.0):
     - Superscript (= 0.2.8)
   - superwallkit_flutter (0.0.1):
     - Flutter
-    - SuperwallKit (= 4.5.2)
+    - SuperwallKit (= 4.7.0)
   - url_launcher_ios (0.0.1):
     - Flutter
   - webview_flutter_wkwebview (0.0.1):
@@ -240,6 +243,7 @@ DEPENDENCIES:
   - health (from `.symlinks/plugins/health/ios`)
   - home_widget (from `.symlinks/plugins/home_widget/ios`)
   - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
+  - in_app_purchase_storekit (from `.symlinks/plugins/in_app_purchase_storekit/darwin`)
   - local_auth_darwin (from `.symlinks/plugins/local_auth_darwin/darwin`)
   - open_file_ios (from `.symlinks/plugins/open_file_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
@@ -324,6 +328,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/home_widget/ios"
   image_picker_ios:
     :path: ".symlinks/plugins/image_picker_ios/ios"
+  in_app_purchase_storekit:
+    :path: ".symlinks/plugins/in_app_purchase_storekit/darwin"
   local_auth_darwin:
     :path: ".symlinks/plugins/local_auth_darwin/darwin"
   open_file_ios:
@@ -384,6 +390,7 @@ SPEC CHECKSUMS:
   health: 785a9a388095ea6414755ff081bf46a4a5fb01b2
   home_widget: f169fc41fd807b4d46ab6615dc44d62adbf9f64f
   image_picker_ios: 7fe1ff8e34c1790d6fff70a32484959f563a928a
+  in_app_purchase_storekit: 22cca7d08eebca9babdf4d07d0baccb73325d3c8
   JPSVolumeButtonHandler: 53110330c9168ed325def93eabff39f0fe3e8082
   libwebp: 02b23773aedb6ff1fd38cec7a77b81414c6842a8
   local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
@@ -412,8 +419,8 @@ SPEC CHECKSUMS:
   sign_in_with_apple: c5dcc141574c8c54d5ac99dd2163c0c72ad22418
   sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
   Superscript: 82dbb40f502823160e75503ebc1b6bac756a503d
-  SuperwallKit: 520fd9dff39358c9708d88cc69c1f4fbd32b3008
-  superwallkit_flutter: 24189eddf53053b67bb8a909556fca71140665c4
+  SuperwallKit: 239843161a144ad08af40906ec0307779abd7d12
+  superwallkit_flutter: 1a8f16ff97d3a3be52be3f6585279cd82209feb2
   url_launcher_ios: 694010445543906933d732453a59da0a173ae33d
   webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
 

--- a/lib/screens/accountdashboard.dart
+++ b/lib/screens/accountdashboard.dart
@@ -29,6 +29,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:macrotracker/screens/delete_account_screen.dart'; // Add this import for the confirmation screen
 import 'package:macrotracker/services/superwall_placements.dart'; // Import Superwall Placements
 import 'package:macrotracker/services/posthog_service.dart'; // Import PostHogService
+import 'package:macrotracker/services/superwall_service.dart'; // Import SuperwallService
 
 class AccountDashboard extends StatefulWidget {
   const AccountDashboard({super.key});
@@ -992,6 +993,64 @@ class _AccountDashboardState extends State<AccountDashboard>
                       onTap: () {
                         HapticFeedback.lightImpact();
                         SuperwallPlacements.showTestPaywall(context);
+                      },
+                      colorScheme: colorScheme,
+                      customColors: customColors,
+                    ),
+                    // Add Test Redeem Action Button
+                    _buildListTile(
+                      icon: CupertinoIcons.gift_fill,
+                      iconColor: Colors.green,
+                      title: 'Test Redeem Action',
+                      subtitle: 'Test the native iOS redemption sheet',
+                      trailing: ElevatedButton(
+                        onPressed: () async {
+                          HapticFeedback.mediumImpact();
+                          
+                          // Show loading indicator
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(
+                              content: Text('Testing redeem action...'),
+                              duration: Duration(seconds: 1),
+                            ),
+                          );
+                          
+                          try {
+                            // Test the redeem action
+                            SuperwallService().testRedeemAction();
+                            
+                            // Show success message
+                            if (mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                  content: Text('Redeem test triggered! Check for redemption sheet.'),
+                                  backgroundColor: Colors.green,
+                                  duration: Duration(seconds: 3),
+                                ),
+                              );
+                            }
+                          } catch (e) {
+                            // Show error message
+                            if (mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                  content: Text('Test failed: ${e.toString()}'),
+                                  backgroundColor: Colors.red,
+                                  duration: Duration(seconds: 3),
+                                ),
+                              );
+                            }
+                          }
+                        },
+                        style: ElevatedButton.styleFrom(
+                          backgroundColor: Colors.green,
+                          foregroundColor: Colors.white,
+                          padding: const EdgeInsets.symmetric(horizontal: 12),
+                        ),
+                        child: const Text('Test'),
+                      ),
+                      onTap: () {
+                        // Button handles the action
                       },
                       colorScheme: colorScheme,
                       customColors: customColors,

--- a/lib/services/superwall_delegate.dart
+++ b/lib/services/superwall_delegate.dart
@@ -1,0 +1,184 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:purchases_flutter/purchases_flutter.dart';
+import 'package:in_app_purchase/in_app_purchase.dart';
+import 'package:in_app_purchase_storekit/in_app_purchase_storekit.dart';
+import 'package:superwallkit_flutter/superwallkit_flutter.dart';
+
+/// Custom SuperwallDelegate implementation to handle custom paywall actions
+/// Extends the official SuperwallDelegate to handle custom actions from paywalls
+class CustomSuperwallDelegate extends SuperwallDelegate {
+  // Prevent duplicate calls by tracking the last action time
+  DateTime? _lastRedeemActionTime;
+  static const Duration _debounceDelay = Duration(seconds: 2);
+  /// Override the official SuperwallDelegate method to handle custom paywall actions
+  @override
+  void handleCustomPaywallAction(String name) {
+    debugPrint('[SuperwallDelegate] Received custom paywall action: $name');
+    
+    switch (name.toLowerCase()) {
+      case 'redeem':
+        _handleRedeemAction();
+        break;
+      case 'restore':
+        _handleRestoreAction();
+        break;
+      default:
+        debugPrint('[SuperwallDelegate] Unknown custom paywall action: $name');
+    }
+  }
+
+  // Required abstract method implementations (minimal implementations)
+  @override
+  void didDismissPaywall(PaywallInfo paywallInfo) {
+    debugPrint('[SuperwallDelegate] Paywall dismissed');
+  }
+
+  @override
+  void didPresentPaywall(PaywallInfo paywallInfo) {
+    debugPrint('[SuperwallDelegate] Paywall presented');
+  }
+
+  @override
+  void handleLog(String level, String scope, String? message, Map<dynamic, dynamic>? info, String? error) {
+    // Optional: implement custom logging if needed
+  }
+
+  @override
+  void handleSuperwallDeepLink(Uri url, List<String> pathComponents, Map<String, String> queryItems) {
+    debugPrint('[SuperwallDelegate] Deep link received: $url');
+  }
+
+  @override
+  void handleSuperwallEvent(SuperwallEventInfo eventInfo) {
+    debugPrint('[SuperwallDelegate] Superwall event: ${eventInfo.event}');
+  }
+
+  @override
+  void paywallWillOpenDeepLink(Uri url) {
+    debugPrint('[SuperwallDelegate] Paywall will open deep link: $url');
+  }
+
+  @override
+  void paywallWillOpenURL(Uri url) {
+    debugPrint('[SuperwallDelegate] Paywall will open URL: $url');
+  }
+
+  @override
+  void subscriptionStatusDidChange(SubscriptionStatus status) {
+    debugPrint('[SuperwallDelegate] Subscription status changed: $status');
+  }
+
+  @override
+  void willDismissPaywall(PaywallInfo paywallInfo) {
+    debugPrint('[SuperwallDelegate] Paywall will dismiss');
+  }
+
+  @override
+  void willPresentPaywall(PaywallInfo paywallInfo) {
+    debugPrint('[SuperwallDelegate] Paywall will present');
+  }
+
+  /// Handle the 'redeem' custom action by opening App Store redeem page
+  /// Uses native redemption sheet on iOS for better UX, with URL fallback
+  void _handleRedeemAction() {
+    // Check for duplicate calls within debounce period
+    final now = DateTime.now();
+    if (_lastRedeemActionTime != null && 
+        now.difference(_lastRedeemActionTime!) < _debounceDelay) {
+      debugPrint('[SuperwallDelegate] Redeem action ignored - too soon after last call (${now.difference(_lastRedeemActionTime!).inMilliseconds}ms ago)');
+      return;
+    }
+    
+    // Update last action time
+    _lastRedeemActionTime = now;
+    
+    debugPrint('[SuperwallDelegate] Opening App Store redeem page...');
+    
+    if (Platform.isIOS) {
+      _presentNativeIOSRedemptionSheet();
+    } else if (Platform.isAndroid) {
+      _openAndroidRedeemPage();
+    } else {
+      debugPrint('[SuperwallDelegate] Redeem action not supported on this platform');
+    }
+  }
+
+  /// Present native iOS App Store redemption sheet
+  Future<void> _presentNativeIOSRedemptionSheet() async {
+    try {
+      debugPrint('[SuperwallDelegate] Presenting native iOS redemption sheet...');
+      
+      // Get the iOS platform addition for in-app purchase
+      InAppPurchaseStoreKitPlatformAddition iosPlatformAddition =
+          InAppPurchase.instance.getPlatformAddition<InAppPurchaseStoreKitPlatformAddition>();
+      
+      // Present the native redemption sheet
+      await iosPlatformAddition.presentCodeRedemptionSheet();
+      
+      debugPrint('[SuperwallDelegate] Native iOS redemption sheet presented successfully');
+    } catch (e) {
+      debugPrint('[SuperwallDelegate] Native redemption sheet failed: $e');
+      debugPrint('[SuperwallDelegate] Falling back to URL-based redemption...');
+      
+      // Fallback to URL-based redemption
+      _openIOSRedeemPageViaURL();
+    }
+  }
+
+  /// Open iOS App Store redeem page using URL scheme (fallback method)
+  void _openIOSRedeemPageViaURL() async {
+    try {
+      const String redeemUrl = 'itms-apps://apps.apple.com/account/balance/redeem';
+      final Uri uri = Uri.parse(redeemUrl);
+      
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+        debugPrint('[SuperwallDelegate] Successfully opened iOS App Store redeem page via URL');
+      } else {
+        debugPrint('[SuperwallDelegate] Could not launch iOS App Store redeem page via URL');
+      }
+    } catch (e) {
+      debugPrint('[SuperwallDelegate] Error opening iOS App Store redeem page via URL: $e');
+    }
+  }
+
+  /// Open Android Play Store redeem page
+  void _openAndroidRedeemPage() async {
+    try {
+      const String redeemUrl = 'https://play.google.com/store/gift';
+      final Uri uri = Uri.parse(redeemUrl);
+      
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+        debugPrint('[SuperwallDelegate] Successfully opened Android Play Store redeem page');
+      } else {
+        debugPrint('[SuperwallDelegate] Could not launch Android Play Store redeem page');
+      }
+    } catch (e) {
+      debugPrint('[SuperwallDelegate] Error opening Android Play Store redeem page: $e');
+    }
+  }
+
+  /// Handle the 'restore' custom action by restoring purchases via RevenueCat
+  void _handleRestoreAction() {
+    debugPrint('[SuperwallDelegate] Handling restore purchases action...');
+    _restorePurchases();
+  }
+
+  /// Restore purchases via RevenueCat
+  Future<void> _restorePurchases() async {
+    try {
+      final customerInfo = await Purchases.restorePurchases();
+      
+      if (customerInfo.entitlements.active.isNotEmpty) {
+        debugPrint('[SuperwallDelegate] Purchases restored successfully');
+      } else {
+        debugPrint('[SuperwallDelegate] No previous purchases found to restore');
+      }
+    } catch (e) {
+      debugPrint('[SuperwallDelegate] Error restoring purchases: $e');
+    }
+  }
+}

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -14,6 +14,7 @@ import firebase_messaging
 import flutter_image_compress_macos
 import flutter_local_notifications
 import google_sign_in_ios
+import in_app_purchase_storekit
 import local_auth_darwin
 import open_file_mac
 import package_info_plus
@@ -36,6 +37,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterImageCompressMacosPlugin.register(with: registry.registrar(forPlugin: "FlutterImageCompressMacosPlugin"))
   FlutterLocalNotificationsPlugin.register(with: registry.registrar(forPlugin: "FlutterLocalNotificationsPlugin"))
   FLTGoogleSignInPlugin.register(with: registry.registrar(forPlugin: "FLTGoogleSignInPlugin"))
+  InAppPurchasePlugin.register(with: registry.registrar(forPlugin: "InAppPurchasePlugin"))
   FLALocalAuthPlugin.register(with: registry.registrar(forPlugin: "FLALocalAuthPlugin"))
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))

--- a/macos/Podfile
+++ b/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.14'
+platform :osx, '10.15'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/macos/Podfile.lock
+++ b/macos/Podfile.lock
@@ -1,0 +1,267 @@
+PODS:
+  - app_links (1.0.0):
+    - FlutterMacOS
+  - app_settings (5.1.1):
+    - FlutterMacOS
+  - AppAuth (1.7.6):
+    - AppAuth/Core (= 1.7.6)
+    - AppAuth/ExternalUserAgent (= 1.7.6)
+  - AppAuth/Core (1.7.6)
+  - AppAuth/ExternalUserAgent (1.7.6):
+    - AppAuth/Core
+  - device_info_plus (0.0.1):
+    - FlutterMacOS
+  - file_selector_macos (0.0.1):
+    - FlutterMacOS
+  - Firebase/CoreOnly (11.8.1):
+    - FirebaseCore (~> 11.8.1)
+  - Firebase/Messaging (11.8.1):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 11.8.0)
+  - firebase_core (3.12.1):
+    - Firebase/CoreOnly (~> 11.8.0)
+    - FlutterMacOS
+  - firebase_messaging (15.2.4):
+    - Firebase/CoreOnly (~> 11.8.0)
+    - Firebase/Messaging (~> 11.8.0)
+    - firebase_core
+    - FlutterMacOS
+  - FirebaseCore (11.8.1):
+    - FirebaseCoreInternal (~> 11.8.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/Logger (~> 8.0)
+  - FirebaseCoreInternal (11.8.0):
+    - "GoogleUtilities/NSData+zlib (~> 8.0)"
+  - FirebaseInstallations (11.8.0):
+    - FirebaseCore (~> 11.8.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - PromisesObjC (~> 2.4)
+  - FirebaseMessaging (11.8.0):
+    - FirebaseCore (~> 11.8.0)
+    - FirebaseInstallations (~> 11.0)
+    - GoogleDataTransport (~> 10.0)
+    - GoogleUtilities/AppDelegateSwizzler (~> 8.0)
+    - GoogleUtilities/Environment (~> 8.0)
+    - GoogleUtilities/Reachability (~> 8.0)
+    - GoogleUtilities/UserDefaults (~> 8.0)
+    - nanopb (~> 3.30910.0)
+  - flutter_image_compress_macos (1.0.0):
+    - FlutterMacOS
+  - flutter_local_notifications (0.0.1):
+    - FlutterMacOS
+  - FlutterMacOS (1.0.0)
+  - google_sign_in_ios (0.0.1):
+    - AppAuth (>= 1.7.4)
+    - Flutter
+    - FlutterMacOS
+    - GoogleSignIn (~> 7.1)
+    - GTMSessionFetcher (>= 3.4.0)
+  - GoogleDataTransport (10.1.0):
+    - nanopb (~> 3.30910.0)
+    - PromisesObjC (~> 2.4)
+  - GoogleSignIn (7.1.0):
+    - AppAuth (< 2.0, >= 1.7.3)
+    - GTMAppAuth (< 5.0, >= 4.1.1)
+    - GTMSessionFetcher/Core (~> 3.3)
+  - GoogleUtilities/AppDelegateSwizzler (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Environment (8.1.0):
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Logger (8.1.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Network (8.1.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Privacy
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (8.1.0)":
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/Privacy (8.1.0)
+  - GoogleUtilities/Reachability (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GoogleUtilities/UserDefaults (8.1.0):
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Privacy
+  - GTMAppAuth (4.1.1):
+    - AppAuth/Core (~> 1.7)
+    - GTMSessionFetcher/Core (< 4.0, >= 3.3)
+  - GTMSessionFetcher (3.5.0):
+    - GTMSessionFetcher/Full (= 3.5.0)
+  - GTMSessionFetcher/Core (3.5.0)
+  - GTMSessionFetcher/Full (3.5.0):
+    - GTMSessionFetcher/Core
+  - local_auth_darwin (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - nanopb (3.30910.0):
+    - nanopb/decode (= 3.30910.0)
+    - nanopb/encode (= 3.30910.0)
+  - nanopb/decode (3.30910.0)
+  - nanopb/encode (3.30910.0)
+  - open_file_mac (0.0.1):
+    - FlutterMacOS
+  - package_info_plus (0.0.1):
+    - FlutterMacOS
+  - path_provider_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - PostHog (3.31.0)
+  - posthog_flutter (0.0.1):
+    - Flutter
+    - FlutterMacOS
+    - PostHog (~> 3.22)
+  - PromisesObjC (2.4.0)
+  - purchases_flutter (8.6.1):
+    - FlutterMacOS
+    - PurchasesHybridCommon (= 13.25.0)
+  - PurchasesHybridCommon (13.25.0):
+    - RevenueCat (= 5.19.0)
+  - RevenueCat (5.19.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+  - sign_in_with_apple (0.0.1):
+    - FlutterMacOS
+  - sqflite_darwin (0.0.4):
+    - Flutter
+    - FlutterMacOS
+  - url_launcher_macos (0.0.1):
+    - FlutterMacOS
+  - webview_flutter_wkwebview (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - app_links (from `Flutter/ephemeral/.symlinks/plugins/app_links/macos`)
+  - app_settings (from `Flutter/ephemeral/.symlinks/plugins/app_settings/macos`)
+  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
+  - file_selector_macos (from `Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos`)
+  - firebase_core (from `Flutter/ephemeral/.symlinks/plugins/firebase_core/macos`)
+  - firebase_messaging (from `Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos`)
+  - flutter_image_compress_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_image_compress_macos/macos`)
+  - flutter_local_notifications (from `Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos`)
+  - FlutterMacOS (from `Flutter/ephemeral`)
+  - google_sign_in_ios (from `Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin`)
+  - local_auth_darwin (from `Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin`)
+  - open_file_mac (from `Flutter/ephemeral/.symlinks/plugins/open_file_mac/macos`)
+  - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
+  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
+  - posthog_flutter (from `Flutter/ephemeral/.symlinks/plugins/posthog_flutter/macos`)
+  - purchases_flutter (from `Flutter/ephemeral/.symlinks/plugins/purchases_flutter/macos`)
+  - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
+  - sign_in_with_apple (from `Flutter/ephemeral/.symlinks/plugins/sign_in_with_apple/macos`)
+  - sqflite_darwin (from `Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin`)
+  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
+  - webview_flutter_wkwebview (from `Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin`)
+
+SPEC REPOS:
+  trunk:
+    - AppAuth
+    - Firebase
+    - FirebaseCore
+    - FirebaseCoreInternal
+    - FirebaseInstallations
+    - FirebaseMessaging
+    - GoogleDataTransport
+    - GoogleSignIn
+    - GoogleUtilities
+    - GTMAppAuth
+    - GTMSessionFetcher
+    - nanopb
+    - PostHog
+    - PromisesObjC
+    - PurchasesHybridCommon
+    - RevenueCat
+
+EXTERNAL SOURCES:
+  app_links:
+    :path: Flutter/ephemeral/.symlinks/plugins/app_links/macos
+  app_settings:
+    :path: Flutter/ephemeral/.symlinks/plugins/app_settings/macos
+  device_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
+  file_selector_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/file_selector_macos/macos
+  firebase_core:
+    :path: Flutter/ephemeral/.symlinks/plugins/firebase_core/macos
+  firebase_messaging:
+    :path: Flutter/ephemeral/.symlinks/plugins/firebase_messaging/macos
+  flutter_image_compress_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_image_compress_macos/macos
+  flutter_local_notifications:
+    :path: Flutter/ephemeral/.symlinks/plugins/flutter_local_notifications/macos
+  FlutterMacOS:
+    :path: Flutter/ephemeral
+  google_sign_in_ios:
+    :path: Flutter/ephemeral/.symlinks/plugins/google_sign_in_ios/darwin
+  local_auth_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/local_auth_darwin/darwin
+  open_file_mac:
+    :path: Flutter/ephemeral/.symlinks/plugins/open_file_mac/macos
+  package_info_plus:
+    :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
+  path_provider_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
+  posthog_flutter:
+    :path: Flutter/ephemeral/.symlinks/plugins/posthog_flutter/macos
+  purchases_flutter:
+    :path: Flutter/ephemeral/.symlinks/plugins/purchases_flutter/macos
+  shared_preferences_foundation:
+    :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
+  sign_in_with_apple:
+    :path: Flutter/ephemeral/.symlinks/plugins/sign_in_with_apple/macos
+  sqflite_darwin:
+    :path: Flutter/ephemeral/.symlinks/plugins/sqflite_darwin/darwin
+  url_launcher_macos:
+    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
+  webview_flutter_wkwebview:
+    :path: Flutter/ephemeral/.symlinks/plugins/webview_flutter_wkwebview/darwin
+
+SPEC CHECKSUMS:
+  app_links: afe860c55c7ef176cea7fb630a2b7d7736de591d
+  app_settings: cd21e176b56f8172043640ade81322a98896bff4
+  AppAuth: d4f13a8fe0baf391b2108511793e4b479691fb73
+  device_info_plus: b0fafc687fb901e2af612763340f1b0d4352f8e5
+  file_selector_macos: 6280b52b459ae6c590af5d78fc35c7267a3c4b31
+  Firebase: 973c28133496aab0223e9ea99f0abafb9f91ad58
+  firebase_core: 3dcdf8453dfb144a023ee70f49e0463b97177f71
+  firebase_messaging: 96fe41b2f8b5bee4e0f21df8d716cb8c9293448c
+  FirebaseCore: 99fe0c4b44a39f37d99e6404e02009d2db5d718d
+  FirebaseCoreInternal: df24ce5af28864660ecbd13596fc8dd3a8c34629
+  FirebaseInstallations: 6c963bd2a86aca0481eef4f48f5a4df783ae5917
+  FirebaseMessaging: 487b634ccdf6f7b7ff180fdcb2a9935490f764e8
+  flutter_image_compress_macos: e68daf54bb4bf2144c580fd4d151c949cbf492f0
+  flutter_local_notifications: 4bf37a31afde695b56091b4ae3e4d9c7a7e6cda0
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  google_sign_in_ios: 19297361f2c51d7d8ac0201b866ef1fa5d1f94a8
+  GoogleDataTransport: aae35b7ea0c09004c3797d53c8c41f66f219d6a7
+  GoogleSignIn: d4281ab6cf21542b1cfaff85c191f230b399d2db
+  GoogleUtilities: 00c88b9a86066ef77f0da2fab05f65d7768ed8e1
+  GTMAppAuth: f69bd07d68cd3b766125f7e072c45d7340dea0de
+  GTMSessionFetcher: 5aea5ba6bd522a239e236100971f10cb71b96ab6
+  local_auth_darwin: 553ce4f9b16d3fdfeafce9cf042e7c9f77c1c391
+  nanopb: fad817b59e0457d11a5dfbde799381cd727c1275
+  open_file_mac: 01874b6d6a2c1485ac9b126d7105b99102dea2cf
+  package_info_plus: f0052d280d17aa382b932f399edf32507174e870
+  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  PostHog: fcb0bc4425a69a2b0ee0ff5782b298a23aedcc83
+  posthog_flutter: 631ab870f7daf1ed190deeb2414eb3e347445f37
+  PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47
+  purchases_flutter: efd7616f31d22f4170bed28994535b6b9145761c
+  PurchasesHybridCommon: f27e7fe57a9934319373b10c260db5d6c10bbb64
+  RevenueCat: 4be87c151dff652d2a5b7af46073db11f01ad93f
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
+  sign_in_with_apple: 6673c03c9e3643f6c8d33601943fbfa9ae99f94e
+  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
+  url_launcher_macos: 0fba8ddabfc33ce0a9afe7c5fef5aab3d8d2d673
+  webview_flutter_wkwebview: 1821ceac936eba6f7984d89a9f3bcb4dea99ebb2
+
+PODFILE CHECKSUM: 9ebaf0ce3d369aaa26a9ea0e159195ed94724cf3
+
+COCOAPODS: 1.16.2

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -27,7 +27,9 @@
 		33CC10F32044A3C60003C045 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F22044A3C60003C045 /* Assets.xcassets */; };
 		33CC10F62044A3C60003C045 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 33CC10F42044A3C60003C045 /* MainMenu.xib */; };
 		33CC11132044BFA00003C045 /* MainFlutterWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33CC11122044BFA00003C045 /* MainFlutterWindow.swift */; };
+		68E04E165EAA8DA3F13353F7 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B6DAB2456BA1F09BB1B68FC1 /* Pods_Runner.framework */; };
 		9B6680ECC6BC4E5B83FE20B1 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = CBA645F996DCB401A2C592FE /* GoogleService-Info.plist */; };
+		BC9C519A5A18B8E98F6D511B /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 943A891E14B39CFA8A88259D /* Pods_RunnerTests.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +63,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1457FAA1C70F0CC58B6E8FA3 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		331C80D5294CF71000263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C80D7294CF71000263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		333000ED22D3DE5D00554162 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
@@ -78,8 +81,15 @@
 		33E51914231749380026EE4D /* Release.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = Release.entitlements; sourceTree = "<group>"; };
 		33E5194F232828860026EE4D /* AppInfo.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = AppInfo.xcconfig; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
+		8810D369449155B508209C71 /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
+		943A891E14B39CFA8A88259D /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
+		AFED98698D759C9946F60223 /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		B6DAB2456BA1F09BB1B68FC1 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C080D3F1D52F80A2C19FCEF7 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		C999A77AC6830A3BCDF5B688 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
 		CBA645F996DCB401A2C592FE /* GoogleService-Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "Runner/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		FB650C6921CD0A2F2C967B17 /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,6 +97,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BC9C519A5A18B8E98F6D511B /* Pods_RunnerTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -94,12 +105,27 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				68E04E165EAA8DA3F13353F7 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		13CA93295AAC5AD555BC3137 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				C999A77AC6830A3BCDF5B688 /* Pods-Runner.debug.xcconfig */,
+				AFED98698D759C9946F60223 /* Pods-Runner.release.xcconfig */,
+				C080D3F1D52F80A2C19FCEF7 /* Pods-Runner.profile.xcconfig */,
+				1457FAA1C70F0CC58B6E8FA3 /* Pods-RunnerTests.debug.xcconfig */,
+				FB650C6921CD0A2F2C967B17 /* Pods-RunnerTests.release.xcconfig */,
+				8810D369449155B508209C71 /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		331C80D6294CF71000263BE5 /* RunnerTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -128,6 +154,7 @@
 				33CC10EE2044A3C60003C045 /* Products */,
 				D73912EC22F37F3D000D13A0 /* Frameworks */,
 				CBA645F996DCB401A2C592FE /* GoogleService-Info.plist */,
+				13CA93295AAC5AD555BC3137 /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -178,6 +205,8 @@
 		D73912EC22F37F3D000D13A0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				B6DAB2456BA1F09BB1B68FC1 /* Pods_Runner.framework */,
+				943A891E14B39CFA8A88259D /* Pods_RunnerTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -189,6 +218,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C80DE294CF71000263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				36E00C45DC3D702A100B790C /* [CP] Check Pods Manifest.lock */,
 				331C80D1294CF70F00263BE5 /* Sources */,
 				331C80D2294CF70F00263BE5 /* Frameworks */,
 				331C80D3294CF70F00263BE5 /* Resources */,
@@ -207,11 +237,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 33CC10FB2044A3C60003C045 /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				D3BA6F41579ACFD6D60A9915 /* [CP] Check Pods Manifest.lock */,
 				33CC10E92044A3C60003C045 /* Sources */,
 				33CC10EA2044A3C60003C045 /* Frameworks */,
 				33CC10EB2044A3C60003C045 /* Resources */,
 				33CC110E2044A8840003C045 /* Bundle Framework */,
 				3399D490228B24CF009A79C7 /* ShellScript */,
+				27911EDAE543D97EE57B5FC2 /* [CP] Embed Pods Frameworks */,
+				4AEDDF39CB873F2058AB0E21 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -295,6 +328,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		27911EDAE543D97EE57B5FC2 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -332,6 +382,67 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$FLUTTER_ROOT\"/packages/flutter_tools/bin/macos_assemble.sh && touch Flutter/ephemeral/tripwire";
+		};
+		36E00C45DC3D702A100B790C /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4AEDDF39CB873F2058AB0E21 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		D3BA6F41579ACFD6D60A9915 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -384,6 +495,7 @@
 /* Begin XCBuildConfiguration section */
 		331C80DB294CF71000263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1457FAA1C70F0CC58B6E8FA3 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -398,6 +510,7 @@
 		};
 		331C80DC294CF71000263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = FB650C6921CD0A2F2C967B17 /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -412,6 +525,7 @@
 		};
 		331C80DD294CF71000263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8810D369449155B508209C71 /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CURRENT_PROJECT_VERSION = 1;
@@ -465,7 +579,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -547,7 +661,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -597,7 +711,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/macos/Runner.xcworkspace/contents.xcworkspacedata
+++ b/macos/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -864,6 +864,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.1+1"
+  in_app_purchase:
+    dependency: "direct main"
+    description:
+      name: in_app_purchase
+      sha256: "5cddd7f463f3bddb1d37a72b95066e840d5822d66291331d7f8f05ce32c24b6c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.3"
+  in_app_purchase_android:
+    dependency: transitive
+    description:
+      name: in_app_purchase_android
+      sha256: "5a02da1399a8faafb36d9b4acca85001b7eefa629f0eeeebf5ad0b04b9df302a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.0+4"
+  in_app_purchase_platform_interface:
+    dependency: transitive
+    description:
+      name: in_app_purchase_platform_interface
+      sha256: "1d353d38251da5b9fea6635c0ebfc6bb17a2d28d0e86ea5e083bf64244f1fb4c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  in_app_purchase_storekit:
+    dependency: transitive
+    description:
+      name: in_app_purchase_storekit
+      sha256: "9e5986db8f7600d62c56739c7d357aa37c4af27035bf00db6f7ab7a8ca952614"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.4.4+1"
   infinite_listview:
     dependency: transitive
     description:
@@ -1601,10 +1633,10 @@ packages:
     dependency: "direct main"
     description:
       name: superwallkit_flutter
-      sha256: "1d120f95ee66744ec33261a2260449bb8ac1de5d6a5cbd500b110db6ce7dab5c"
+      sha256: "6dfaaf11afeb25a3d8349240c6ee7438095d97a070cda11aa986ddceea352b21"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.4"
+    version: "2.4.2"
   syncfusion_flutter_charts:
     dependency: "direct main"
     description:
@@ -1910,5 +1942,5 @@ packages:
     source: hosted
     version: "2.0.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.35.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.14
+version: 1.0.15
 environment:
   sdk: ^3.6.0
 # Dependencies specify other packages that your package needs in order to work.
@@ -70,8 +70,9 @@ dependencies:
   provider: ^6.1.2
   purchases_flutter: ^8.6.1
   purchases_ui_flutter: ^8.6.1
+  in_app_purchase: ^3.2.2
   rename_app: ^1.6.2
-  superwallkit_flutter: ^2.0.5
+  superwallkit_flutter: ^2.4.2
   settings_ui: ^2.0.2
   sign_in_with_apple: ^6.1.0
   smooth_page_indicator: ^1.1.0


### PR DESCRIPTION
## Summary by Sourcery

Integrate a custom Superwall delegate to support 'redeem' and 'restore' paywall actions with native iOS redemption sheet, add a dashboard button for testing, bump dependencies, and ship detailed documentation

New Features:
- Implement CustomSuperwallDelegate to handle 'redeem' and 'restore' actions with native sheet support
- Expose handleRedeemAction, handleCustomAction, testRedeemAction, and handleRestoreAction in SuperwallService
- Add "Test Redeem Action" button in AccountDashboard to trigger the iOS redemption sheet

Enhancements:
- Upgrade superwallkit_flutter to 2.4.2 and add in_app_purchase for native code redemption
- Remove legacy subscription sync code and streamline delegate-based Superwall configuration

Build:
- Bump app version to 1.0.15 and update pubspec dependencies
- Raise macOS platform to 10.15 and register InAppPurchasePlugin in GeneratedPluginRegistrant.swift

Documentation:
- Add extensive documentation for iOS App Store redemption methods and Superwall custom action implementation

Chores:
- Clean up commented-out subscription synchronization code